### PR TITLE
Fixed CSS attribute highlighting

### DIFF
--- a/colors/mac_classic.vim
+++ b/colors/mac_classic.vim
@@ -192,6 +192,7 @@ hi link cssBoxProp cssDefinition
 hi link cssGeneratedContentProp cssDefinition
 hi link cssUIProp cssDefinition
 hi cssCommonAttr  guifg=#00BC41 ctermfg=35
+hi link cssAttr cssCommonAttr
 hi link cssRenderAttr cssCommonAttr
 hi link cssTextAttr cssCommonAttr
 hi link cssFontAttr cssCommonAttr


### PR DESCRIPTION
The colour #00BC41 was not being applied to CSS attributes for me (using MacVim 7.3). This fixed it.
